### PR TITLE
Ignore example when running doc tests. Add test that only truly runs …

### DIFF
--- a/src/privdrop.rs
+++ b/src/privdrop.rs
@@ -4,10 +4,27 @@ use nix::unistd;
 use std::ffi::CString;
 use std::path::{Path, PathBuf};
 
+#[test]
+fn test_privdrop ()
+{
+    use std;
+    use std::io::Write;
+
+    if unistd::geteuid() == 0 {
+        PrivDrop::default()
+            .chroot("/var/empty")
+            .user("nobody").unwrap()
+            .apply()
+            .unwrap_or_else(|e| { panic!("Failed to drop privileges: {}", e) });
+    } else {
+        writeln!(std::io::stderr(), "Test was skipped because it needs to be run as root.").unwrap();
+    }
+}
+
 /// `PrivDrop` structure
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// privdrop::PrivDrop::default()
 ///     .chroot("/var/empty")
 ///     .user("nobody").unwrap()


### PR DESCRIPTION
…when running as root and that will otherwise write to stderr that it was skipped. Note that from the perspective of cargo test, all tests that are run either pass or fail, so to cargo test it looks like a test that passed. Ideally I would have wanted the test to tell the test runner that it was skipped but that is not currently possible. See also https://stackoverflow.com/questions/43557542/how-to-conditionally-skip-tests-based-on-runtime-information/43558165#43558165.