### PR TITLE
PrivDrop::default().apply() should always succeed

### DIFF
--- a/src/privdrop.rs
+++ b/src/privdrop.rs
@@ -78,7 +78,6 @@ impl PrivDrop {
 
     /// Apply the changes
     pub fn apply(self) -> Result<(), PrivDropError> {
-        Self::preload()?;
         let ids = self.lookup_ids()?;
         self.do_chroot()?.do_idchange(ids)?;
         Ok(())
@@ -111,6 +110,7 @@ impl PrivDrop {
     fn do_chroot(mut self) -> Result<Self, PrivDropError> {
         if let Some(chroot) = self.chroot.take() {
             Self::uidcheck()?;
+            Self::preload()?;
             unistd::chdir(&chroot)?;
             unistd::chroot(&chroot)?;
             unistd::chdir("/")?

--- a/src/privdrop.rs
+++ b/src/privdrop.rs
@@ -8,6 +8,13 @@ use nix::unistd;
 use super::errors::*;
 
 #[test]
+fn test_default_privdrop() {
+    PrivDrop::default()
+        .apply()
+        .expect("A default PrivDrop should always succeed");
+}
+
+#[test]
 fn test_privdrop() {
     use std;
     use std::io::Write;
@@ -175,7 +182,9 @@ impl PrivDrop {
     }
 
     fn do_idchange(&self, ids: UidGid) -> Result<(), PrivDropError> {
-        Self::uidcheck()?;
+        if ids.gid.is_some() || ids.uid.is_some() {
+            Self::uidcheck()?;
+        }
 
         if let Some(gid) = ids.gid {
             if unsafe { libc::setgroups(1, &gid) } != 0 {


### PR DESCRIPTION
It seems natural to conditionally feed configuration options to a PrivDrop, and to expect `apply()` to be a no-op if no privilege changes were actually requested.

This makes it so.