### PR TITLE
Limit nix features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ travis-ci = { repository = "jedisct1/rust-privdrop" }
 
 [dependencies]
 libc = "0.2"
-nix = "0.24"
+nix = { version = "0.24", default-features = false, features = ["fs", "user"] }


### PR DESCRIPTION
This reduces build time and removes memoffset as an indirect dependency.

This reduces my local clean build times from ~4.6s to ~2.5s.